### PR TITLE
feat(tool-gateway): implement bloque 2

### DIFF
--- a/platform/tool-gateway/filesystem/filesystem-read-adapter.ts
+++ b/platform/tool-gateway/filesystem/filesystem-read-adapter.ts
@@ -1,0 +1,58 @@
+import { readFile } from "node:fs/promises";
+import { IToolAdapter, ToolResult } from "../types";
+import { resolveSandboxPath } from "./path-utils";
+
+type ReadInput = {
+  path: string;
+  encoding?: "utf8";
+};
+
+export class FilesystemReadAdapter implements IToolAdapter {
+  public readonly spec = {
+    name: "filesystem.read",
+    description: "Read a UTF-8 text file from the sandbox.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["path"],
+      properties: {
+        path: { type: "string", minLength: 1 },
+        encoding: { type: "string", enum: ["utf8"] },
+      },
+    },
+    outputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["path", "content"],
+      properties: {
+        path: { type: "string" },
+        content: { type: "string" },
+      },
+    },
+    permissions: ["fs:read"],
+    sideEffects: "fs" as const,
+  };
+
+  constructor(private readonly sandboxRoot: string) {}
+
+  async invoke(input: Record<string, unknown>): Promise<ToolResult> {
+    try {
+      const payload = input as ReadInput;
+      const resolvedPath = resolveSandboxPath(this.sandboxRoot, payload.path);
+      const content = await readFile(resolvedPath, payload.encoding ?? "utf8");
+
+      return {
+        ok: true,
+        output: {
+          path: resolvedPath,
+          content,
+        },
+      };
+    } catch (error) {
+      return {
+        ok: false,
+        error: error instanceof Error ? error.message : "Failed to read file",
+      };
+    }
+  }
+}

--- a/platform/tool-gateway/filesystem/filesystem-write-adapter.ts
+++ b/platform/tool-gateway/filesystem/filesystem-write-adapter.ts
@@ -1,0 +1,61 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { IToolAdapter, ToolResult } from "../types";
+import { resolveSandboxPath } from "./path-utils";
+
+type WriteInput = {
+  path: string;
+  content: string;
+};
+
+export class FilesystemWriteAdapter implements IToolAdapter {
+  public readonly spec = {
+    name: "filesystem.write",
+    description: "Write UTF-8 text content to a file in the sandbox.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["path", "content"],
+      properties: {
+        path: { type: "string", minLength: 1 },
+        content: { type: "string" },
+      },
+    },
+    outputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["path", "bytesWritten"],
+      properties: {
+        path: { type: "string" },
+        bytesWritten: { type: "number", minimum: 0 },
+      },
+    },
+    permissions: ["fs:write"],
+    sideEffects: "fs" as const,
+  };
+
+  constructor(private readonly sandboxRoot: string) {}
+
+  async invoke(input: Record<string, unknown>): Promise<ToolResult> {
+    try {
+      const payload = input as WriteInput;
+      const resolvedPath = resolveSandboxPath(this.sandboxRoot, payload.path);
+
+      await mkdir(path.dirname(resolvedPath), { recursive: true });
+      await writeFile(resolvedPath, payload.content, "utf8");
+
+      return {
+        ok: true,
+        output: {
+          path: resolvedPath,
+          bytesWritten: new TextEncoder().encode(payload.content).length,
+        },
+      };
+    } catch (error) {
+      return {
+        ok: false,
+        error: error instanceof Error ? error.message : "Failed to write file",
+      };
+    }
+  }
+}

--- a/platform/tool-gateway/filesystem/path-utils.ts
+++ b/platform/tool-gateway/filesystem/path-utils.ts
@@ -1,0 +1,19 @@
+import path from "node:path";
+
+export function resolveSandboxPath(sandboxRoot: string, inputPath: string): string {
+  const normalizedRoot = path.resolve(sandboxRoot);
+  const candidate = path.isAbsolute(inputPath)
+    ? path.resolve(inputPath)
+    : path.resolve(normalizedRoot, inputPath);
+
+  if (!isInside(normalizedRoot, candidate)) {
+    throw new Error(`Path is outside sandbox: ${inputPath}`);
+  }
+
+  return candidate;
+}
+
+function isInside(rootPath: string, candidatePath: string): boolean {
+  const normalizedRoot = rootPath.endsWith(path.sep) ? rootPath : `${rootPath}${path.sep}`;
+  return candidatePath === rootPath || candidatePath.startsWith(normalizedRoot);
+}

--- a/platform/tool-gateway/index.ts
+++ b/platform/tool-gateway/index.ts
@@ -4,3 +4,5 @@ export * from "./mcp/types";
 export * from "./mcp/mcp-client";
 export * from "./mcp/mcp-tool-adapter";
 export * from "./mcp/register-mcp-tools";
+export * from "./filesystem/filesystem-read-adapter";
+export * from "./filesystem/filesystem-write-adapter";

--- a/platform/tool-gateway/tool-registry.test.ts
+++ b/platform/tool-gateway/tool-registry.test.ts
@@ -1,0 +1,104 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "bun:test";
+import { FilesystemReadAdapter } from "./filesystem/filesystem-read-adapter";
+import { FilesystemWriteAdapter } from "./filesystem/filesystem-write-adapter";
+import { ToolGatewayLogger, ToolInvocationLog } from "./types";
+import { ToolRegistry } from "./tool-registry";
+
+class InMemoryLogger implements ToolGatewayLogger {
+  public readonly entries: ToolInvocationLog[] = [];
+
+  log(entry: ToolInvocationLog): void {
+    this.entries.push(entry);
+  }
+}
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.map((dir) => rm(dir, { recursive: true, force: true })));
+  tempDirs.length = 0;
+});
+
+async function createRegistry() {
+  const sandboxRoot = await mkdtemp(path.join(os.tmpdir(), "tool-gateway-test-"));
+  tempDirs.push(sandboxRoot);
+
+  const logger = new InMemoryLogger();
+  const registry = new ToolRegistry(logger);
+  registry.register(new FilesystemReadAdapter(sandboxRoot));
+  registry.register(new FilesystemWriteAdapter(sandboxRoot));
+
+  return { sandboxRoot, logger, registry };
+}
+
+describe("ToolRegistry", () => {
+  it("supports filesystem.write and filesystem.read with schema validation", async () => {
+    const { registry } = await createRegistry();
+
+    const writeResult = await registry.invoke(
+      "filesystem.write",
+      { path: "notes/summary.txt", content: "hola mundo" },
+      "task-1",
+      "trace-1"
+    );
+    expect(writeResult.ok).toBeTrue();
+
+    const readResult = await registry.invoke(
+      "filesystem.read",
+      { path: "notes/summary.txt" },
+      "task-1",
+      "trace-1"
+    );
+    expect(readResult.ok).toBeTrue();
+    expect(readResult.output?.content).toBe("hola mundo");
+  });
+
+  it("rejects invalid input before adapter invocation", async () => {
+    const { registry } = await createRegistry();
+
+    const result = await registry.invoke("filesystem.write", { path: "x.txt" }, "task-2");
+
+    expect(result.ok).toBeFalse();
+    expect(result.error).toContain("Invalid input");
+  });
+
+  it("rejects paths outside sandbox", async () => {
+    const { registry } = await createRegistry();
+
+    const result = await registry.invoke(
+      "filesystem.read",
+      { path: "../outside.txt" },
+      "task-3"
+    );
+
+    expect(result.ok).toBeFalse();
+    expect(result.error).toContain("outside sandbox");
+  });
+
+  it("returns tool specs and logs task_id, input and output", async () => {
+    const { logger, registry, sandboxRoot } = await createRegistry();
+
+    await registry.invoke(
+      "filesystem.write",
+      { path: "out.txt", content: "abc" },
+      "task-4",
+      "trace-4"
+    );
+
+    const content = await readFile(path.join(sandboxRoot, "out.txt"), "utf8");
+    expect(content).toBe("abc");
+
+    const specs = registry.getToolSpecs();
+    expect(specs.map((spec) => spec.name)).toEqual(["filesystem.read", "filesystem.write"]);
+
+    expect(logger.entries.length).toBe(1);
+    expect(logger.entries[0]?.toolName).toBe("filesystem.write");
+    expect(logger.entries[0]?.taskId).toBe("task-4");
+    expect(logger.entries[0]?.traceId).toBe("trace-4");
+    expect(logger.entries[0]?.input).toEqual({ path: "out.txt", content: "abc" });
+    expect(logger.entries[0]?.output).toBeDefined();
+  });
+});

--- a/platform/tool-gateway/tool-registry.ts
+++ b/platform/tool-gateway/tool-registry.ts
@@ -1,7 +1,19 @@
-import { IToolAdapter, ToolInvocation, ToolResult } from "./types";
+import Ajv, { ValidateFunction } from "ajv";
+import {
+  IToolAdapter,
+  ToolGatewayLogger,
+  ToolInvocation,
+  ToolResult,
+  ToolSpec,
+} from "./types";
 
 export class ToolRegistry {
   private readonly adapters = new Map<string, IToolAdapter>();
+  private readonly ajv = new Ajv({ allErrors: true, strict: false });
+  private readonly inputValidators = new Map<string, ValidateFunction>();
+  private readonly outputValidators = new Map<string, ValidateFunction>();
+
+  constructor(private readonly logger?: ToolGatewayLogger) {}
 
   register(adapter: IToolAdapter): void {
     if (this.adapters.has(adapter.spec.name)) {
@@ -14,12 +26,124 @@ export class ToolRegistry {
     return [...this.adapters.keys()].sort();
   }
 
-  async invoke(invocation: ToolInvocation): Promise<ToolResult> {
+  getToolSpecs(): ToolSpec[] {
+    return [...this.adapters.values()]
+      .map((adapter) => adapter.spec)
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  async invoke(invocation: ToolInvocation): Promise<ToolResult>;
+  async invoke(
+    toolName: string,
+    input: Record<string, unknown>,
+    taskId: string,
+    traceId?: string
+  ): Promise<ToolResult>;
+  async invoke(
+    invocationOrToolName: ToolInvocation | string,
+    input?: Record<string, unknown>,
+    taskId?: string,
+    traceId?: string
+  ): Promise<ToolResult> {
+    const invocation =
+      typeof invocationOrToolName === "string"
+        ? ({
+            toolName: invocationOrToolName,
+            input: input ?? {},
+            taskId: taskId ?? "unknown-task",
+            traceId,
+          } satisfies ToolInvocation)
+        : invocationOrToolName;
+
     const adapter = this.adapters.get(invocation.toolName);
     if (!adapter) {
-      return { ok: false, error: `Unknown tool: ${invocation.toolName}` };
+      const error = `Unknown tool: ${invocation.toolName}`;
+      this.logError(invocation, error);
+      return { ok: false, error };
     }
 
-    return adapter.invoke(invocation.input, invocation.traceId);
+    if (!this.validateInput(adapter.spec, invocation.input)) {
+      const validate = this.getInputValidator(adapter.spec);
+      const error = `Invalid input for tool ${adapter.spec.name}: ${this.ajv.errorsText(
+        validate.errors
+      )}`;
+      this.logError(invocation, error);
+      return { ok: false, error };
+    }
+
+    const result = await adapter.invoke(invocation.input, invocation.traceId);
+
+    if (result.ok) {
+      const output = result.output ?? {};
+      if (!this.validateOutput(adapter.spec, output)) {
+        const validate = this.getOutputValidator(adapter.spec);
+        const error = `Invalid output for tool ${adapter.spec.name}: ${this.ajv.errorsText(
+          validate.errors
+        )}`;
+        this.logError(invocation, error, output);
+        return { ok: false, error };
+      }
+
+      this.logInfo(invocation, output);
+      return { ok: true, output };
+    }
+
+    this.logError(invocation, result.error ?? "Tool invocation failed");
+    return result;
+  }
+
+  private getInputValidator(spec: ToolSpec): ValidateFunction {
+    let validator = this.inputValidators.get(spec.name);
+    if (!validator) {
+      validator = this.ajv.compile(spec.inputSchema);
+      this.inputValidators.set(spec.name, validator);
+    }
+    return validator;
+  }
+
+  private getOutputValidator(spec: ToolSpec): ValidateFunction {
+    let validator = this.outputValidators.get(spec.name);
+    if (!validator) {
+      validator = this.ajv.compile(spec.outputSchema);
+      this.outputValidators.set(spec.name, validator);
+    }
+    return validator;
+  }
+
+  private validateInput(spec: ToolSpec, input: Record<string, unknown>): boolean {
+    return Boolean(this.getInputValidator(spec)(input));
+  }
+
+  private validateOutput(spec: ToolSpec, output: Record<string, unknown>): boolean {
+    return Boolean(this.getOutputValidator(spec)(output));
+  }
+
+  private logInfo(invocation: ToolInvocation, output: Record<string, unknown>): void {
+    this.logger?.log({
+      level: "info",
+      message: "Tool invocation succeeded",
+      toolName: invocation.toolName,
+      taskId: invocation.taskId,
+      traceId: invocation.traceId,
+      input: invocation.input,
+      output,
+    });
+  }
+
+  private logError(
+    invocation: ToolInvocation,
+    error: string,
+    output?: Record<string, unknown>
+  ): void {
+    this.logger?.log({
+      level: "error",
+      message: "Tool invocation failed",
+      toolName: invocation.toolName,
+      taskId: invocation.taskId,
+      traceId: invocation.traceId,
+      input: invocation.input,
+      output,
+      error,
+    });
   }
 }

--- a/platform/tool-gateway/types.ts
+++ b/platform/tool-gateway/types.ts
@@ -12,6 +12,7 @@ export interface ToolSpec {
 export interface ToolInvocation {
   toolName: string;
   input: Record<string, unknown>;
+  taskId: string;
   traceId?: string;
 }
 
@@ -24,4 +25,19 @@ export interface ToolResult {
 export interface IToolAdapter {
   spec: ToolSpec;
   invoke(input: Record<string, unknown>, traceId?: string): Promise<ToolResult>;
+}
+
+export interface ToolInvocationLog {
+  level: "info" | "error";
+  message: string;
+  toolName: string;
+  taskId: string;
+  traceId?: string;
+  input?: Record<string, unknown>;
+  output?: Record<string, unknown>;
+  error?: string;
+}
+
+export interface ToolGatewayLogger {
+  log(entry: ToolInvocationLog): void;
 }


### PR DESCRIPTION
## Resumen
- añade validación de input/output con AJV en ToolRegistry
- implementa adapters filesystem.read y filesystem.write con sandbox path checks
- agrega getToolSpecs() y logging por invocación con task_id/trace_id
- incluye tests del registry (schema inválido, path fuera de sandbox, happy path)

## Verificación
- bun test platform/tool-gateway/tool-registry.test.ts

closes #5 