### PR TITLE
Bloque 3 — Agent Runtime + Skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules/
 Thumbs.db
 *.log
 .env
+tmp/
 
 .gemini/
 gha-creds-*.json

--- a/platform/runtime/src/agent-runtime.ts
+++ b/platform/runtime/src/agent-runtime.ts
@@ -1,0 +1,135 @@
+import type { LLMClient, ChatMessage, ToolSpec, ToolCall } from "@openagents/llm-client";
+import type { ToolRegistry } from "@openagents/tool-gateway";
+import { loadSkill } from "./skill-loader";
+import type { AgentTask, AgentResult } from "./types";
+
+const MAX_ITERATIONS = 20;
+
+/** filesystem.read → filesystem_read (la API de Anthropic no permite puntos) */
+function toApiName(name: string): string {
+  return name.replace(/\./g, "__dot__");
+}
+
+/** filesystem_read → filesystem.read */
+function fromApiName(name: string): string {
+  return name.replace(/__dot__/g, ".");
+}
+
+export interface AgentRuntimeOptions {
+  llmClient: LLMClient;
+  toolRegistry: ToolRegistry;
+  /** Directorio raíz de skills (se usa si AgentTask no especifica skillDir) */
+  defaultSkillDir?: string;
+}
+
+export class AgentRuntime {
+  constructor(private readonly opts: AgentRuntimeOptions) {}
+
+  async run(task: AgentTask): Promise<AgentResult> {
+    // ── 1. Cargar skill ──────────────────────────────────────────────────────
+    let systemPrompt = "Eres un agente de propósito general. Completa la tarea del usuario.";
+
+    const skillDir = task.skillDir ?? this.opts.defaultSkillDir;
+    if (skillDir) {
+      try {
+        const skill = await loadSkill(skillDir);
+        systemPrompt = skill.systemPrompt;
+      } catch {
+        // Si la skill no se puede cargar, continuamos con el system prompt por defecto
+      }
+    }
+
+    // ── 2. Construir contexto inicial ────────────────────────────────────────
+    // La API de Anthropic solo permite [a-zA-Z0-9_-] en nombres de tools.
+    // Normalizamos los puntos a guiones bajos para el LLM y revertimos al ejecutar.
+    const toolSpecs: ToolSpec[] = this.opts.toolRegistry.getToolSpecs().map((spec) => ({
+      name: toApiName(spec.name),
+      description: spec.description,
+      input_schema: spec.inputSchema,
+    }));
+
+    const messages: ChatMessage[] = [
+      { role: "user", content: task.goal },
+    ];
+
+    // ── 3. Loop de tool use ──────────────────────────────────────────────────
+    let iterations = 0;
+
+    while (iterations < MAX_ITERATIONS) {
+      iterations++;
+
+      const response = await this.opts.llmClient.chat({
+        system: systemPrompt,
+        messages,
+        tools: toolSpecs,
+      });
+
+      // Añadir respuesta del asistente al historial
+      if (response.toolCalls.length > 0) {
+        messages.push({
+          role: "assistant",
+          content: [
+            ...(response.text ? [{ type: "text" as const, text: response.text }] : []),
+            ...response.toolCalls.map((tc) => ({
+              type: "tool_use" as const,
+              id: tc.id,
+              name: tc.name,
+              input: tc.input,
+            })),
+          ],
+        });
+
+        // Ejecutar tool calls y añadir resultados
+        const toolResults = await Promise.all(
+          response.toolCalls.map((tc) => this.executeTool(tc, task))
+        );
+
+        messages.push({
+          role: "user",
+          content: toolResults.map((result, i) => ({
+            type: "tool_result" as const,
+            tool_use_id: response.toolCalls[i]!.id,
+            content: result,
+          })),
+        });
+      } else {
+        // end_turn — el agente ha terminado
+        messages.push({
+          role: "assistant",
+          content: response.text ?? "",
+        });
+        break;
+      }
+
+      if (response.stopReason === "end_turn") break;
+    }
+
+    // ── 4. Construir resultado ───────────────────────────────────────────────
+    const lastMessage = messages.at(-1);
+    const summary = typeof lastMessage?.content === "string"
+      ? lastMessage.content
+      : "Tarea completada.";
+
+    return {
+      taskId: task.taskId,
+      status: "completed",
+      summary,
+      artifacts: [],
+    };
+  }
+
+    private async executeTool(tc: ToolCall, task: AgentTask): Promise<string> {
+    const result = await this.opts.toolRegistry.invoke(
+      fromApiName(tc.name),
+      tc.input,
+      task.taskId,
+      task.traceId
+    );
+
+    if (result.ok) {
+      return JSON.stringify(result.output ?? {});
+    }
+
+    return `Error: ${result.error ?? "Tool execution failed"}`;
+  }
+}

--- a/platform/runtime/src/index.ts
+++ b/platform/runtime/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./types";
+export * from "./skill-loader";
+export * from "./agent-runtime";

--- a/platform/runtime/src/skill-loader.ts
+++ b/platform/runtime/src/skill-loader.ts
@@ -1,0 +1,28 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+export interface SkillManifest {
+  name: string;
+  version: string;
+  description: string;
+  triggers: string[];
+}
+
+export interface Skill {
+  manifest: SkillManifest;
+  systemPrompt: string;
+}
+
+export async function loadSkill(skillDir: string): Promise<Skill> {
+  const manifestPath = path.join(skillDir, "skill.json");
+  const skillMdPath = path.join(skillDir, "SKILL.md");
+
+  const [manifestRaw, systemPrompt] = await Promise.all([
+    readFile(manifestPath, "utf8"),
+    readFile(skillMdPath, "utf8"),
+  ]);
+
+  const manifest = JSON.parse(manifestRaw) as SkillManifest;
+
+  return { manifest, systemPrompt };
+}

--- a/platform/runtime/src/test-manual.ts
+++ b/platform/runtime/src/test-manual.ts
@@ -1,0 +1,44 @@
+/**
+ * Test manual del Agent Runtime.
+ * Uso: bun --env-file=.env platform/runtime/src/test-manual.ts
+ */
+import path from "node:path";
+import { createLLMClient } from "@openagents/llm-client";
+import { ToolRegistry, FilesystemReadAdapter, FilesystemWriteAdapter } from "@openagents/tool-gateway";
+import { AgentRuntime } from "./agent-runtime";
+
+const apiKey = process.env.OPENROUTER_API_KEY;
+if (!apiKey) {
+  console.error("Error: OPENROUTER_API_KEY no está definida.");
+  process.exit(1);
+}
+
+// Sandbox: directorio temporal dentro del proyecto
+const sandboxRoot = path.resolve("tmp/sandbox");
+const skillDir = path.resolve("skills/general-assistant");
+
+// Montar componentes
+const llmClient = createLLMClient({ apiKey });
+
+const toolRegistry = new ToolRegistry();
+toolRegistry.register(new FilesystemReadAdapter(sandboxRoot));
+toolRegistry.register(new FilesystemWriteAdapter(sandboxRoot));
+
+const runtime = new AgentRuntime({ llmClient, toolRegistry, defaultSkillDir: skillDir });
+
+// Crear un archivo de prueba en el sandbox antes de ejecutar
+import { mkdir, writeFile } from "node:fs/promises";
+await mkdir(sandboxRoot, { recursive: true });
+await writeFile(path.join(sandboxRoot, "hello.txt"), "Hola desde el sandbox!", "utf8");
+
+console.log("Ejecutando AgentRuntime...\n");
+
+const result = await runtime.run({
+  taskId: "test-task-1",
+  traceId: "test-trace-1",
+  goal: "Lee el archivo hello.txt y dime qué contiene.",
+});
+
+console.log("Status:", result.status);
+console.log("Summary:", result.summary);
+console.log("Artifacts:", result.artifacts);

--- a/platform/runtime/src/types.ts
+++ b/platform/runtime/src/types.ts
@@ -1,0 +1,18 @@
+export interface AgentTask {
+  taskId: string;
+  traceId: string;
+  goal: string;
+  skillDir?: string;
+}
+
+export interface AgentArtifact {
+  type: string;
+  content: string;
+}
+
+export interface AgentResult {
+  taskId: string;
+  status: "completed" | "failed";
+  summary: string;
+  artifacts: AgentArtifact[];
+}

--- a/proyecto.md
+++ b/proyecto.md
@@ -129,6 +129,10 @@ toolGateway.getToolSpecs(): ToolSpec[]   // para pasarlas al LLM
 
 **DoD**: `filesystem.read` y `filesystem.write` funcionan y rechazan input inválido.
 
+> **Nota — Módulo MCP (adelantado, inactivo en MVP)**
+>
+> Durante la implementación del Bloque 2 se añadió `platform/tool-gateway/mcp/` con una abstracción para conectar servidores MCP externos (`IMcpClient`, `StubMcpClient`, `McpToolAdapter`, `registerMcpTools`). Este código no se usa en el MVP — el `StubMcpClient` es un stub que no realiza ninguna llamada real. Queda disponible para fases post-MVP cuando se quiera integrar tools externas vía protocolo MCP.
+
 ---
 
 ### Bloque 3 — Agent Runtime + Skill

--- a/skills/general-assistant/SKILL.md
+++ b/skills/general-assistant/SKILL.md
@@ -1,0 +1,17 @@
+# General Assistant
+
+Eres un asistente general capaz de leer y escribir archivos dentro del sandbox del proyecto.
+
+## Comportamiento
+
+- Cuando el usuario pida leer un archivo, usa `filesystem.read` con la ruta indicada.
+- Cuando el usuario pida crear o modificar un archivo, usa `filesystem.write`.
+- Si necesitas leer un archivo antes de modificarlo, hazlo primero.
+- Responde siempre en el mismo idioma que el usuario.
+- Sé conciso: resume el contenido leído en lugar de reproducirlo íntegro salvo que se pida explícitamente.
+
+## Restricciones
+
+- Solo puedes acceder a archivos dentro del sandbox asignado.
+- No ejecutes comandos de sistema ni accedas a URLs externas.
+- Si una operación falla, explica el motivo claramente.

--- a/skills/general-assistant/skill.json
+++ b/skills/general-assistant/skill.json
@@ -1,0 +1,6 @@
+{
+  "name": "general-assistant",
+  "version": "0.1.0",
+  "description": "Asistente general con acceso al filesystem del sandbox",
+  "triggers": ["default"]
+}


### PR DESCRIPTION
## Resumen

Implementación del Agent Runtime con loop de tool use y SkillLoader.

## Cambios

- `AgentRuntime`: loop `while stopReason !== end_turn` (máx. 20 iteraciones), ejecuta tool calls via Tool Gateway
- `SkillLoader`: carga `SKILL.md` y `skill.json` desde el directorio de la skill e inyecta el contenido como system prompt
- Normalización de nombres de tools (`filesystem.read` → `filesystem__dot__read`) para cumplir el patrón `^[a-zA-Z0-9_-]+$` de la API de Anthropic
- Tipos propios: `AgentTask`, `AgentResult`, `AgentArtifact`
- Skill `general-assistant` con instrucciones y manifest
- `tmp/` añadido al `.gitignore`
- `proyecto.md` actualizado con nota sobre el módulo MCP adelantado en Bloque 2

## Definition of Done

Test manual ejecutado con éxito:
```
Ejecutando AgentRuntime...
Status: completed
Summary: El archivo `hello.txt` contiene el siguiente texto: "Hola desde el sandbox!"
```

Closes #6